### PR TITLE
fix(mutex): don't use recursion

### DIFF
--- a/src/09-naked-promise-mutex.js
+++ b/src/09-naked-promise-mutex.js
@@ -3,7 +3,7 @@ import {makeMutex} from './common/mutex.js'
 // eslint-disable-next-line node/no-missing-import
 import {setTimeout} from 'timers/promises'
 
-const mutex = makeMutex()
+const mutexLock = makeMutex()
 
 const people = await Promise.all([
   getInformationAboutPerson('Luke Skywalker'),
@@ -16,13 +16,13 @@ people.forEach((person) => console.log(person.name))
 
 /** @param {string} person */
 async function getInformationAboutPerson(person) {
-  await mutex.lock()
+  const unlock = await mutexLock()
   try {
     const personSearch = await starWars(`people/?search=${encodeURIComponent(person)}`)
     await setTimeout(500)
 
     return personSearch.results[0]
   } finally {
-    await mutex.unlock()
+    unlock()
   }
 }

--- a/src/common/mutex.js
+++ b/src/common/mutex.js
@@ -1,24 +1,16 @@
-export function makeMutex() {
-  /** @type {Promise<any> | undefined} */
-  let theLock
-  /** @type {((value: any) => void) | undefined} */
-  let nakedResolve
-  return {
-    /** @returns {Promise<void>} */
-    async lock() {
-      if (!theLock) {
-        theLock = new Promise((resolve) => (nakedResolve = resolve))
-      } else {
-        await theLock
-        await this.lock()
-      }
-    },
-    unlock() {
-      if (theLock) {
-        nakedResolve?.(undefined)
-        nakedResolve = undefined
-        theLock = undefined
-      }
-    },
-  }
+function makeMutex() {
+  let latestLock;
+  
+  return async function lock() {
+    let nakedResolve;
+    const currLatestLock = latestLock;
+    
+    latestLock = new Promise((resolve) => (nakedResolve = resolve));
+    
+    await currLatestLock;
+    
+    return function unlock() {
+      nakedResolve();
+    }
+  };
 }

--- a/src/common/mutex.js
+++ b/src/common/mutex.js
@@ -1,16 +1,21 @@
-function makeMutex() {
-  let latestLock;
-  
+export function makeMutex() {
+  /** @type {Promise<void> | undefined} */
+  let latestLock
+
+  /** @returns {Promise<() => void>} */
   return async function lock() {
-    let nakedResolve;
-    const currLatestLock = latestLock;
-    
-    latestLock = new Promise((resolve) => (nakedResolve = resolve));
-    
-    await currLatestLock;
-    
+    /** @type {((value: any) => void) | undefined} */
+    let nakedResolve
+
+    /* @type {Promise<void> | undefined} */
+    const currLatestLock = latestLock
+
+    latestLock = new Promise((resolve) => (nakedResolve = resolve))
+
+    await currLatestLock
+
     return function unlock() {
-      nakedResolve();
+      nakedResolve?.(undefined)
     }
-  };
+  }
 }


### PR DESCRIPTION
As you may know recursion is not very good because it can lead to stack overflow of the call stack

Instead I changed it to save only the last lock as it always will be the last to resolve (if you want to have the ability to release all lock this can be added)

I'll update the rest of the code with this change if you are interested

WDYT?